### PR TITLE
fix cf package issue

### DIFF
--- a/dockerfiles/ubuntu/Dockerfile
+++ b/dockerfiles/ubuntu/Dockerfile
@@ -3,8 +3,8 @@ ARG builder_image=concourse/golang-builder
 
 FROM ${builder_image} as builder
 RUN apt update && apt install -y --no-install-recommends \
-    curl \
-    jq \
+  curl \
+  jq \
   && rm -rf /var/lib/apt/lists/*
 RUN mkdir -p /assets
 WORKDIR /assets
@@ -16,25 +16,26 @@ RUN go build -o /assets/in github.com/cloud-gov/cf-resource/in/cmd/in
 RUN go build -o /assets/out github.com/cloud-gov/cf-resource/out/cmd/out
 RUN go build -o /assets/check github.com/cloud-gov/cf-resource/check/cmd/check
 RUN set -e; for pkg in $(go list ./... | grep -v "acceptance"); do \
-		go test -o "/tests/$(basename $pkg).test" -c $pkg; \
-	done
+  go test -o "/tests/$(basename $pkg).test" -c $pkg; \
+  done
 
 FROM ${base_image} AS resource
 RUN apt update && apt upgrade -y -o Dpkg::Options::="--force-confdef"
 RUN apt update && apt install -y --no-install-recommends \
-    tzdata \
-    ca-certificates \
+  tzdata \
+  ca-certificates \
   && rm -rf /var/lib/apt/lists/*
 COPY --from=builder assets/ /opt/resource/
 RUN chmod +x /opt/resource/*
-RUN mv /opt/resource/cf /usr/bin/cf
+# move cf and cf8 so the symlink works
+RUN mv /opt/resource/cf* /usr/bin/
 
 FROM resource AS tests
 COPY --from=builder /tests /go-tests
 COPY out/assets /go-tests/assets
 WORKDIR /go-tests
 RUN set -e; for test in /go-tests/*.test; do \
-		$test; \
-	done
+  $test; \
+  done
 
 FROM resource


### PR DESCRIPTION
## Changes proposed in this pull request:

- Updates dockerfile to copy over all cf files so that the symlink between the cf and cf8 commands doesn't break

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Fixing cf command
