### PR TITLE
change builder image

### DIFF
--- a/dockerfiles/ubuntu/Dockerfile
+++ b/dockerfiles/ubuntu/Dockerfile
@@ -1,5 +1,5 @@
 ARG base_image
-ARG builder_image=concourse/golang-builder
+ARG builder_image=golang
 
 FROM ${builder_image} as builder
 RUN apt update && apt install -y --no-install-recommends \


### PR DESCRIPTION
## Changes proposed in this pull request:

- Change builder to official golang image since concourse golang image now uses wolfi

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Changes the builder image
