### PR TITLE
fix file group ownership

### DIFF
--- a/dockerfiles/ubuntu/Dockerfile
+++ b/dockerfiles/ubuntu/Dockerfile
@@ -29,6 +29,10 @@ COPY --from=builder assets/ /opt/resource/
 RUN chmod +x /opt/resource/*
 # move cf and cf8 so the symlink works
 RUN mv /opt/resource/cf* /usr/bin/
+RUN chgrp root /usr/bin/cf && \
+  chgrp root/usr/bin/cf8 && \
+  chgrp root /bin/cf && \
+  chgrp root /bin/cf8
 
 FROM resource AS tests
 COPY --from=builder /tests /go-tests

--- a/dockerfiles/ubuntu/Dockerfile
+++ b/dockerfiles/ubuntu/Dockerfile
@@ -30,7 +30,7 @@ RUN chmod +x /opt/resource/*
 # move cf and cf8 so the symlink works
 RUN mv /opt/resource/cf* /usr/bin/
 RUN chgrp root /usr/bin/cf && \
-  chgrp root/usr/bin/cf8 && \
+  chgrp root /usr/bin/cf8 && \
   chgrp root /bin/cf && \
   chgrp root /bin/cf8
 


### PR DESCRIPTION
## Changes proposed in this pull request:

- Fixes group ownership of files

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

System command files need to be owned by root group to meet stig requirements
