### PR TITLE
change owner of file and symlink

### DIFF
--- a/dockerfiles/ubuntu/Dockerfile
+++ b/dockerfiles/ubuntu/Dockerfile
@@ -30,6 +30,7 @@ RUN chmod +x /opt/resource/*
 # move cf and cf8 so the symlink works
 RUN mv /opt/resource/cf* /usr/bin/
 RUN chgrp root /usr/bin/cf8 && chgrp -h root /usr/bin/cf
+RUN chown root /usr/bin/cf8 && chown -h /usr/bin/cf
 
 FROM resource AS tests
 COPY --from=builder /tests /go-tests


### PR DESCRIPTION
## Changes proposed in this pull request:

- Fixes the file ownership of cf8 and its symlink

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

File owner is also a requirement of stigs
